### PR TITLE
Disabled APT auto update in droplets for Ansible-101

### DIFF
--- a/ansible-101/cloudinit.txt
+++ b/ansible-101/cloudinit.txt
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This is NOT a cloud-init file
+# as https://docs.digitalocean.com/products/droplets/how-to/provide-user-data/ suggests,
+# we may insert a payload script. 
+
+# If we had cloud-init file, we could have used this:
+# package_update: false
+# package_upgrade: false
+
+# but we are simply rewriting this config file 
+echo "APT::Periodic::Update-Package-Lists \"0\";" > /etc/apt/apt.conf.d/20auto-upgrades
+echo "APT::Periodic::Unattended-Upgrade \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades

--- a/ansible-101/site-digitalocean.yml
+++ b/ansible-101/site-digitalocean.yml
@@ -39,6 +39,7 @@
       region: fra1
       image: docker-18-04
       wait_timeout: 500
+      user_data: "{{ lookup('file', 'cloudinit.txt') }}" # b64encode is not needed in Ansible
     register: my_droplet
     with_items:
     - deleteme-1


### PR DESCRIPTION
Automatic APT upgrades at VM start overload vCPUs, expecially when we're using an old LTS image, `docker-18-04`. In local lab scenarios like this we may disable them using `user_data` Ansible argument to provide a shell script payload.