### PR TITLE
ansible-101: use different debian image in sshd container

### DIFF
--- a/ansible-101/Dockerfile.ssh
+++ b/ansible-101/Dockerfile.ssh
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:stable
 RUN apt-get -y update && apt-get -y install python sshpass openssh-server
 RUN apt-get -y clean
 RUN apt-get -y autoremove

--- a/ansible-101/Dockerfile.ssh
+++ b/ansible-101/Dockerfile.ssh
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:bullseye
 RUN apt-get -y update && apt-get -y install python sshpass openssh-server
 RUN apt-get -y clean
 RUN apt-get -y autoremove

--- a/ansible-101/site-digitalocean.yml
+++ b/ansible-101/site-digitalocean.yml
@@ -25,6 +25,7 @@
     droplet_names:
       - deleteme-1
       - deleteme-2
+
   tasks:
   - name: Retrieve ssh key id.
     community.digitalocean.digital_ocean_sshkey_info:

--- a/ansible-101/site-digitalocean.yml
+++ b/ansible-101/site-digitalocean.yml
@@ -19,12 +19,9 @@
   vars:
     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     ssh_pubkeys:
-      - rpolli-ed25519
-      - esavo-rsa
-      - dabbasciano-rsa
+      - d8o-mac
     droplet_names:
-      - deleteme-1
-      - deleteme-2
+      - ansible-test
 
   tasks:
   - name: Retrieve ssh key id.
@@ -132,7 +129,7 @@
 
     - name: Download course
       git:
-        repo: https://github.com/ioggstream/python-course.git
+        repo: https://github.com/DomenicoCutrupi/python-course.git
         version: ansible-2023
         dest: /root/python-course
       ignore_errors: true

--- a/ansible-101/site-digitalocean.yml
+++ b/ansible-101/site-digitalocean.yml
@@ -19,10 +19,12 @@
   vars:
     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     ssh_pubkeys:
-      - d8o-mac
+      - rpolli-ed25519
+      - esavo-rsa
+      - dabbasciano-rsa
     droplet_names:
-      - ansible-test
-
+      - deleteme-1
+      - deleteme-2
   tasks:
   - name: Retrieve ssh key id.
     community.digitalocean.digital_ocean_sshkey_info:

--- a/ansible-101/site-digitalocean.yml
+++ b/ansible-101/site-digitalocean.yml
@@ -129,7 +129,7 @@
 
     - name: Download course
       git:
-        repo: https://github.com/DomenicoCutrupi/python-course.git
+        repo: https://github.com/ioggstream/python-course.git
         version: ansible-2023
         dest: /root/python-course
       ignore_errors: true


### PR DESCRIPTION
L'immagine debian:stable-slim non permette più il comando "apt-get install python"